### PR TITLE
Rename namespace from DatasetsParquet:: to Datasets:: for dataset

### DIFF
--- a/example/tlc-green-taxi-trip.rb
+++ b/example/tlc-green-taxi-trip.rb
@@ -2,7 +2,7 @@
 
 require "datasets-parquet"
 
-trips = DatasetsParquet::TLC::GreenTaxiTrip.new(year: 2022, month: 1)
+trips = Datasets::TLC::GreenTaxiTrip.new(year: 2022, month: 1)
 
 p trips.to_arrow
 # #<Arrow::Table:0x1474998d0 ptr=0x136e79d60>

--- a/example/tlc-yellow-taxi-trip.rb
+++ b/example/tlc-yellow-taxi-trip.rb
@@ -2,7 +2,7 @@
 
 require "datasets-parquet"
 
-trips = DatasetsParquet::TLC::YellowTaxiTrip.new(year: 2022, month: 1)
+trips = Datasets::TLC::YellowTaxiTrip.new(year: 2022, month: 1)
 
 p trips.to_arrow
 # #<Arrow::Table:0x128949110 ptr=0x102c10b60>

--- a/lib/datasets-parquet/tlc/green-taxi-trip.rb
+++ b/lib/datasets-parquet/tlc/green-taxi-trip.rb
@@ -1,6 +1,6 @@
-module DatasetsParquet
+module Datasets
   module TLC
-    class GreenTaxiTrip < Datasets::Dataset
+    class GreenTaxiTrip < Dataset
       class Record < Struct.new(:vendor,
                                 :lpep_pickup_datetime,
                                 :lpep_dropoff_datetime,

--- a/lib/datasets-parquet/tlc/yellow-taxi-trip.rb
+++ b/lib/datasets-parquet/tlc/yellow-taxi-trip.rb
@@ -1,6 +1,6 @@
-module DatasetsParquet
+module Datasets
   module TLC
-    class YellowTaxiTrip < Datasets::Dataset
+    class YellowTaxiTrip < Dataset
       class Record < Struct.new(:vendor,
                                 :tpep_pickup_datetime,
                                 :tpep_dropoff_datetime,

--- a/test/test-tlc-green-taxi-trip.rb
+++ b/test/test-tlc-green-taxi-trip.rb
@@ -2,7 +2,7 @@ class TLCGreenTaxiTripTest < Test::Unit::TestCase
   def setup
     @default_timezone_env = ENV['TZ']
     ENV['TZ'] = 'UTC'
-    @dataset = DatasetsParquet::TLC::GreenTaxiTrip.new(year: 2022, month: 1)
+    @dataset = Datasets::TLC::GreenTaxiTrip.new(year: 2022, month: 1)
   end
 
   def teardown

--- a/test/test-tlc-yellow-taxi-trip.rb
+++ b/test/test-tlc-yellow-taxi-trip.rb
@@ -2,7 +2,7 @@ class TLCYellowTaxiTripTest < Test::Unit::TestCase
   def setup
     @default_timezone_env = ENV['TZ']
     ENV['TZ'] = 'UTC'
-    @dataset = DatasetsParquet::TLC::YellowTaxiTrip.new(year: 2022, month: 1)
+    @dataset = Datasets::TLC::YellowTaxiTrip.new(year: 2022, month: 1)
   end
 
   def teardown


### PR DESCRIPTION
## Related Issue
- https://github.com/red-data-tools/red-datasets-parquet/issues/9

## Objective
- Users don't have to care whether the dataset uses Apache Parquet or not when they use Red Datasets at the same time.

## What I did
- Renamed namespace from DatasetsParquet:: to Datasets:: for dataset

## Notes for reviewers
Please give me some advice.
CI failed on Windows OS now. ~~I think this error happened in the [Red Arrow](https://github.com/apache/arrow/tree/master/ruby/red-arrow) layer.~~

The reason is that MSYS2 has to be rebuilt because of using aws-c-auth and aws-crt-cpp.
- ref https://issues.apache.org/jira/browse/ARROW-18095

^ @kou told me this one and has already dealt with it So we will have to wait for it.

<details>
<summary> Error Log </summary>

```console
Run bundle exec rake
C:/hostedtoolcache/windows/Ruby/2.7.6/x64/bin/ruby.exe test/run-test.rb
(NULL)-WARNING **: Failed to load shared library 'libarrow-glib-900.dll' referenced by the typelib: 'libarrow-glib-900.dll': The specified procedure could not be found.
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/loader.rb:592:in `load_interface_info'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/loader.rb:75:in `load_info'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/loader.rb:44:in `block (2 levels) in load'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/repository.rb:34:in `block (2 levels) in each'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/repository.rb:33:in `times'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/repository.rb:33:in `block in each'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/repository.rb:32:in `each'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/repository.rb:32:in `each'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/loader.rb:43:in `block in load'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/loader.rb:622:in `prepare_class'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/loader.rb:41:in `load'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/gobject-introspection-4.0.3/lib/gobject-introspection/loader.rb:25:in `load'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/red-arrow-9.0.0/lib/arrow/loader.rb:24:in `load'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/red-arrow-9.0.0/lib/arrow.rb:29:in `<module:Arrow>'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/red-arrow-9.0.0/lib/arrow.rb:25:in `<top (required)>'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/red-datasets-arrow-0.0.3/lib/datasets-arrow/arrowable.rb:1:in `require'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/red-datasets-arrow-0.0.3/lib/datasets-arrow/arrowable.rb:1:in `<top (required)>'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/red-datasets-arrow-0.0.3/lib/datasets-arrow.rb:5:in `require'
	from C:/hostedtoolcache/windows/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/red-datasets-arrow-0.0.3/lib/datasets-arrow.rb:5:in `<top (required)>'
	from D:/a/red-datasets-parquet/red-datasets-parquet/lib/datasets-parquet.rb:1:in `require'
	from D:/a/red-datasets-parquet/red-datasets-parquet/lib/datasets-parquet.rb:1:in `<top (required)>'
	from D:/a/red-datasets-parquet/red-datasets-parquet/test/helper.rb:6:in `require'
	from D:/a/red-datasets-parquet/red-datasets-parquet/test/helper.rb:6:in `<top (required)>'
	from test/run-test.rb:14:in `require_relative'
	from test/run-test.rb:14:in `<main>'
```

</details>